### PR TITLE
doc: notification perm support out of date

### DIFF
--- a/packages/perms/blueprint.md
+++ b/packages/perms/blueprint.md
@@ -44,7 +44,7 @@ The current supported permissions are:
 | Events             | `event`             | ✔  | ✔       |
 | Bluetooth          | `bluetooth`         | ✔  | ✔(api >= 31)      |
 | Reminders          | `reminder`          | ✔  | ❌      |
-| Push Notifications | `notification`      | ✔  | ❌      |
+| Push Notifications | `notification`      | ✔  | ✔ (api >= 33)       |
 | Background Refresh | `backgroundRefresh` | ✔  | ❌      |
 | Speech Recognition | `speechRecognition` | ✔  | ❌      |
 | Media Library      | `mediaLibrary`      | ✔  | ❌      |


### PR DESCRIPTION
Docs were not in sync with the code. Code reflects that notification permission request will ask for permissions on devices running Android 13+